### PR TITLE
Issue 17

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 	helper_method :current_person
 
 	def godmother?
-	  if current_person && current_person.role_name == :godmother
+	  if current_person && current_person.isGodmother
       true
     else
       false

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,13 @@
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'
+  smtp_settings = {
+    :address              => "smtp.ccchb.de",
+    :port                 => 587,
+    :domain               => "ccchb.de",
+    :user_name            => "chaosmentors@ccchb.de",
+    :password             => "g3Y763BDgVQxOmrV2H5g",
+    :authentication       => "plain",
+    :enable_starttls_auto => true
+  }
 end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -1,5 +1,5 @@
 class PersonMailer < ApplicationMailer
-  default from: "chaospatinnen@kleinerdrei.net"
+  default from: "chaosmentors@ccchb.de"
 
   def verification_email
     @person = params[:person]

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -90,6 +90,10 @@ class Person < ApplicationRecord
     end
   end
 
+  def is_godmother
+    self.isGodmother
+  end
+
   def align_group_state
     unless self.state_name == :done
       if self.state_name == :in_group && self.group_id.blank?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,14 +12,14 @@ class Person < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :about, presence: true
-  validates :password, length: { in: 14..72 }, if: Proc.new { |p| p.role == 3 && p.password != nil }
-  validates :password, confirmation: true, if: Proc.new { |p| p.role == 3 }
+  validates :password, length: { in: 14..72 }, if: Proc.new { |p| p.isGodmother && p.password != nil }
+  validates :password, confirmation: true, if: Proc.new { |p| p.isGodmother }
   validates :password_confirmation, presence: true, unless: Proc.new { |p| p.password.blank? }
 
   ROLES = {
     1 => :mentee,
     2 => :mentor,
-    3 => :godmother
+    3 => :godmother # This role means, you are a godmother only, but not a mentor
   }
 
   STATES = {
@@ -33,7 +33,11 @@ class Person < ApplicationRecord
   }
 
   def role_name
-    ROLES[self.role]
+    if self.isGodmother
+      ROLES[3]
+    else
+      ROLES[self.role]
+    end
   end
 
   def role_name=(r)
@@ -41,6 +45,9 @@ class Person < ApplicationRecord
 
     if r
       self.role = r
+      if self.role == 3
+        self.isGodmother = true
+      end
     else
       self.role = 1
     end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -23,6 +23,13 @@
     <%= form.text_field :tag_list, { placeholder: "e.g.: english, german, coding, antifa, security, freifunk, feminism, …", data: raw(tags) } %>
     <small id="pronoun-help" class="form-text text-muted">Please give yourself a few tags, describing the languages you speak and your interests. This helps us to form fitting groups.</small>
   </div>
+
+  <% if current_person.isGodmother? && @person != current_person  && @person.role > 1 %>
+  <div class="form-group">
+    <%= form.check_box :is_godmother %>
+  </div>
+<% end %>
+
   <% if action_name == 'new' || action_name == 'create' -%>
     <div class="form-group">
       <label>

--- a/db/migrate/20200816193644_add_is_godmother_to_people.rb
+++ b/db/migrate/20200816193644_add_is_godmother_to_people.rb
@@ -1,0 +1,5 @@
+class AddIsGodmotherToPeople < ActiveRecord::Migration[5.2]
+  def change
+    add_column :people, :isGodmother, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_09_171254) do
+ActiveRecord::Schema.define(version: 2020_08_16_193644) do
 
   create_table "groups", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2018_12_09_171254) do
     t.integer "state", default: 1
     t.string "password_digest"
     t.integer "group_id"
+    t.boolean "isGodmother"
     t.index ["email"], name: "index_people_on_email", unique: true
     t.index ["random_id"], name: "index_people_on_random_id", unique: true
     t.index ["verification_token"], name: "index_people_on_verification_token", unique: true


### PR DESCRIPTION
I have added a flag, that allows to set the godmother status independently from the user's role. The "Godmother" role is now reserved for people, who are godmothers, but not mentors. 

The new flag can be set in the edit view, so every user who can edit others can edit the  godmother flag, provided they are godmothers themselves.

The flag can be set under the following conditions:

- The user editing is a godmother
- The edited user is at least a mentor. mentees cannot be godmothers.
- The user doesn't edit their own profile. This prevents godmothers from accidentally removing all godmothers, which would leave the system without an admin.
